### PR TITLE
Invalid inputs handling

### DIFF
--- a/src/client/main/main.js
+++ b/src/client/main/main.js
@@ -29,7 +29,7 @@ export async function onNavigate() {
         const priceTagElement = productBox.querySelector(".price-tag");
         const imageDivElement = productBox.querySelector(".image-container");
 
-        titleElement.innerText = listing.description;
+        titleElement.innerText = listing.title;
 
         categoryLabelElement.innerText = listing.category;
 

--- a/src/client/product/product.html
+++ b/src/client/product/product.html
@@ -29,7 +29,7 @@
         Price: $<span id="price-tag"></span>
       </div>
       <div>
-        Description: <span id="price-tag"></span>
+        Description: <span id="descrip"></span>
       </div>
       <div>
         Seller: <span id="seller-label"></span>

--- a/src/client/product/product.js
+++ b/src/client/product/product.js
@@ -13,7 +13,7 @@ async function renderDescription(listing) {
     const priceTag = document.getElementById('price-tag');
     const sellerLabel = document.getElementById('seller-label');
     const sellerEmailLabel = document.getElementById('seller-email-label');
-    const descriptionSection = document.getElementById('description-section');
+    const descriptionSection = document.getElementById('descrip');
 
     titleSpan.textContent = listing.title;
 

--- a/src/client/seller/seller.js
+++ b/src/client/seller/seller.js
@@ -141,9 +141,10 @@ async function renderDescription(listing) {
         quantityLabel.textContent = listing.quantity;
     });
 
+    const currencyPattern = /^\d+(\.\d{1,2})?$/;
     priceInput.addEventListener("change", () => {
         const newCost = Number(priceInput.value); // Number constructor used since it is strict
-        if (isFinite(newCost)) {
+        if (isFinite(newCost) && currencyPattern.test(newCost)) {
             priceInput.classList.remove("invalid-input");
             listing.cost = newCost
         } else {
@@ -164,10 +165,21 @@ async function renderDescription(listing) {
 
     postButton.addEventListener("click", async () => {
         try {
+            if (!currencyPattern.test(priceInput.value)) throw new Error("price");
+            if (!listing.quantity) throw new Error("quantity");
             await putListing(listing);
             loadView("main");
-        } catch {
-            alert("Cannot upload listing!");
+        } catch (e) {
+            switch (e.message) {
+                case "price":
+                    alert("Please enter a valid price");
+                    break;
+                case "quantity":
+                    alert("Please enter a valid quantity");
+                    break;
+                default:
+                    alert("Cannot upload listing!");
+            }
         }
     })
 }

--- a/src/client/seller/seller.js
+++ b/src/client/seller/seller.js
@@ -135,7 +135,9 @@ async function renderDescription(listing) {
         quantityLabel.textContent = listing.quantity;
     });
     quantitySubtractButton.addEventListener("click", async () => {
-        listing.quantity--;
+        if (listing.quantity > 1) {
+            listing.quantity--;
+        }
         quantityLabel.textContent = listing.quantity;
     });
 


### PR DESCRIPTION
Added handling for invalid seller quantities and prices. Quantities cannot go below 1 and must exist before posting, and price inputs must match basic price pattern. Also swapped listing titles to be what the main page listings show instead of description (assuming that was the intention) and moved description in product page next to the description label.